### PR TITLE
Fix problem with Chezmoi binary when using Chezmoi as Snap

### DIFF
--- a/plugin/vim-chezmoi.vim
+++ b/plugin/vim-chezmoi.vim
@@ -35,6 +35,11 @@ function g:Chezmoi(...)
 	let l:parentPidFileSplitted = split(l:parentPidFileContents, " ")
 
 	call s:Log(l:parentPidFileSplitted)
+
+	if l:parentPidFileSplitted[0] =~# '^/'          
+                let l:parentPidFileSplitted[0] = split(parentPidFileSplitted[0], '/')[-1]
+        endif
+        
 	if l:parentPidFileSplitted[0] == l:chezmoiBinary && l:parentPidFileSplitted[1] == "edit"
 		let l:dotfile = s:GetDotfileFromCommand(l:parentPidFileSplitted)
 		call s:Log("This vim session was launched via chezmoi edit. The dotfile that is being edited is " . l:dotfile)


### PR DESCRIPTION
Fix problem with Chezmoi binary when using a Snap. Get just the filename instead of all path.

Closes #1